### PR TITLE
[Feature] Fixing curve interactions

### DIFF
--- a/contracts/interfaces/IStableSwap.sol
+++ b/contracts/interfaces/IStableSwap.sol
@@ -9,6 +9,12 @@ interface IStableSwap {
         uint256 min_amount
     ) external;
 
+    function remove_liquidity_one_coin(
+        uint256 amount,
+        uint256 i,
+        uint256 min_amount
+    ) external;
+
     function add_liquidity(uint256[2] calldata amounts, uint256 min_mint_amount)
         external;
 
@@ -19,6 +25,11 @@ interface IStableSwap {
         external;
 
     function calc_withdraw_one_coin(uint256 _token_amount, int128 i)
+        external
+        view
+        returns (uint256);
+
+    function calc_withdraw_one_coin(uint256 _token_amount, uint256 i)
         external
         view
         returns (uint256);
@@ -52,4 +63,31 @@ interface IStableSwap {
         external
         view
         returns (uint256);
+
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 min_dy
+    ) external;
+
+    function exchange(
+        uint256 i,
+        uint256 j,
+        uint256 dx,
+        uint256 min_dy,
+        bool useEth
+    ) external;
+
+    function get_dy(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256);
+
+    function get_dy(
+        uint256 i,
+        uint256 j,
+        uint256 dx
+    ) external view returns (uint256);
 }

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -28,6 +28,8 @@ interface IVault is IERC20 {
 
     function totalAssets() external view returns (uint256);
 
+    function availableDepositLimit() external view returns (uint256);
+
     function permit(
         address owner,
         address spender,


### PR DESCRIPTION
The curve pools can have different signatures and execution based on the type of pool. The main issue is from TriCrypto.

- Remove some useless calls
- Add a constant for TriCrypto to handle it's specific signatures
- Fix some issue linked to the Curve FactoryRegistry

List of valid swaps [here](https://gist.github.com/Major-Eth/63a8e8bc96b1340e5caa81b4df806b70)